### PR TITLE
Moved all the context creation/switching over from vision to the base env

### DIFF
--- a/mimoEnv/envs/mimo_env.py
+++ b/mimoEnv/envs/mimo_env.py
@@ -479,7 +479,7 @@ class MIMoEnv(robot_env.RobotEnv, utils.EzPickle):
     def _reset_sim(self):
         """Resets a simulation and indicates whether or not it was successful.
 
-        Resets the simulation state and returns whether or not the reset was successfull. This is useful if your
+        Resets the simulation state and returns whether or not the reset was successful. This is useful if your
         resetting function has a randomized component that can end up in an illegal state. In this case this function
         will be called again until a valid state is reached.
 
@@ -686,11 +686,11 @@ class MIMoEnv(robot_env.RobotEnv, utils.EzPickle):
 
     # ====================== gym rendering =======================================================
 
-    def _get_viewer(self, mode: str):
+    def _get_viewer(self, mode):
         """ Handles render contexts.
 
         Args:
-            mode: One of 'human' or 'rgb_array'. If 'rgb_array' an offscreen render context is used, otherwise we render
+            mode (str): One of "human" or "rgb_array". If "rgb_array" an offscreen render context is used, otherwise we render
             to an interactive viewer window.
 
         """
@@ -717,30 +717,32 @@ class MIMoEnv(robot_env.RobotEnv, utils.EzPickle):
         glfw.make_context_current(window)
 
     def close(self):
+        """ Removes all references to render contexts, etc..."""
         if self.viewer is not None:
             # self.viewer.finish()
             self.viewer = None
             self._viewers = {}
             self.offscreen_context = None
 
-    def render(self, mode="human", width=DEFAULT_SIZE, height=DEFAULT_SIZE, camera_name: str = None, camera_id: int = None):
+    def render(self, mode="human", width=DEFAULT_SIZE, height=DEFAULT_SIZE, camera_name=None, camera_id=None):
         """ General rendering function for cameras or interactive environment.
 
-        Two modes: 'human' and 'rgb_array'. human renders an interactive window, while rgb array renders an image to an array
-        Parameters determine the size of the rendered image.
-        With mode 'rgb_array' we can also specify a camera by either name or id and then this camera is rendered to an image.
-
-        RGB mode:
-        The vertical field of view is defined in the scene xml, with the horizontal field of view determined
-        by the rendering resolution.
+        There are two modes, "human" and "rgb_array". In "human" we render to an interactive window, ignoring all other
+        parameters. Width and size are determined by the size of the window (which can be resized).
+        In mode "rgb_array" we return the rendered image as a numpy array. The size of the image is determined by the
+        'width' and 'height' parameters. A specific camera can be rendered by providing either its name or its ID. By
+        default the standard Mujoco free cam is used. The vertical field of view for each camera is defined in the
+        scene xml, with the horizontal field of view determined by the rendering resolution.
 
         Args:
-            width: The width of the output image
-            height: The height of the output image
-            camera_name: The name of the camera that will be used for rendering.
+            mode (str): One of either "human" or "rgb_array".
+            width (int): The width of the output image
+            height (int): The height of the output image
+            camera_name (str): The name of the camera that will be rendered. Default None.
+            camera_id (int): The ID of the camera that will be rendered. Default None.
 
         Returns:
-            A numpy array with the containing the output image.
+            A numpy array with the output image or None if mode is 'human'.
         """
         self._render_callback()
 

--- a/mimoEnv/envs/mimo_env.py
+++ b/mimoEnv/envs/mimo_env.py
@@ -727,15 +727,15 @@ class MIMoEnv(robot_env.RobotEnv, utils.EzPickle):
     def render(self, mode="human", width=DEFAULT_SIZE, height=DEFAULT_SIZE, camera_name=None, camera_id=None):
         """ General rendering function for cameras or interactive environment.
 
-        There are two modes, "human" and "rgb_array". In "human" we render to an interactive window, ignoring all other
+        There are two modes, 'human' and 'rgb_array'. In 'human' we render to an interactive window, ignoring all other
         parameters. Width and size are determined by the size of the window (which can be resized).
-        In mode "rgb_array" we return the rendered image as a numpy array. The size of the image is determined by the
-        'width' and 'height' parameters. A specific camera can be rendered by providing either its name or its ID. By
+        In mode 'rgb_array' we return the rendered image as a numpy array. The size of the image is determined by the
+        `width` and `height` parameters. A specific camera can be rendered by providing either its name or its ID. By
         default the standard Mujoco free cam is used. The vertical field of view for each camera is defined in the
         scene xml, with the horizontal field of view determined by the rendering resolution.
 
         Args:
-            mode (str): One of either "human" or "rgb_array".
+            mode (str): One of either 'human' or 'rgb_array'.
             width (int): The width of the output image
             height (int): The height of the output image
             camera_name (str): The name of the camera that will be rendered. Default None.
@@ -746,7 +746,7 @@ class MIMoEnv(robot_env.RobotEnv, utils.EzPickle):
         """
         self._render_callback()
 
-        assert camera_name is None or camera_id is None, "only one of camera_name or camera_id can be supplied"
+        assert camera_name is None or camera_id is None, "Only one of camera_name or camera_id can be supplied!"
         if camera_name is not None:
             camera_id = self.sim.model.camera_name2id(camera_name)
 

--- a/mimoVision/vision.py
+++ b/mimoVision/vision.py
@@ -14,8 +14,7 @@ class Vision:
 
     This class defines the functions that all implementing classes must provide.
     :meth:`.get_vision_obs` should produce the vision outputs that will be returned to the environment. These outputs
-    should also be stored in :attr:`.sensor_outputs`. :meth:`.render_camera` can be used to render any camera in the
-    scene.
+    should also be stored in :attr:`.sensor_outputs`.
 
     Attributes:
         env: The environment to which this module will be attached
@@ -65,7 +64,6 @@ class SimpleVision(Vision):
         camera_parameters: A dictionary containing the configuration.
         sensor_outputs: A dictionary containing the outputs produced by the sensors. This is populated by
             :meth:`.get_vision_obs`
-        viewer: The currently active render context.
 
     """
     def __init__(self, env, camera_parameters):
@@ -83,7 +81,7 @@ class SimpleVision(Vision):
 
         This function renders each camera with the resolution as defined in :attr:`.camera_parameters` using an
         offscreen render context. The images are stored in :attr:`.sensor_outputs` under the name of the associated
-        camera. Uses :meth:`.render_camera`.
+        camera.
 
         Returns:
             A dictionary of numpy arrays. Keys are camera names and the values are the corresponding images.


### PR DESCRIPTION
This moves all the render context handling and switching away from the vision module towards the base environment. This makes it possible for the rendering to work properly even without using the vision setup, like just recording a demo video.